### PR TITLE
Use setuptools_scm to infer package version from tag

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,5 @@
+[build-system]
+requires = ["setuptools>=45", "setuptools_scm[toml]>=6.2"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools_scm]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,5 @@
 [metadata]
 name = leukeleu-django-checks
-version = 1.0.0
 url = https://github.com/leukeleu/leukeleu-django-checks
 author = Jaap Roes
 author_email = jroes@leukeleu.nl


### PR DESCRIPTION
This should make it possible to release new versions using GitHub actions alone