### PR TITLE
Exclude all tests from distribution

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -21,6 +21,7 @@ packages = find:
 
 [options.packages.find]
 exclude =
+    tests
     tests.*
 
 [options.extras_require]


### PR DESCRIPTION
Top level test modules were included in previous versions