### PR TITLE
Replace usage of re_path by path

### DIFF
--- a/tests/urls/urls.py
+++ b/tests/urls/urls.py
@@ -1,8 +1,8 @@
 from django.http import HttpResponse
-from django.urls import path, re_path
+from django.urls import path
 
 urlpatterns = [
     # pragma: no cover
     path("not-admin/", lambda request: HttpResponse("Hello regular user!")),
-    re_path(r"(?P<name>\w+)/", lambda request, name: HttpResponse(f"Hello {name}!")),
+    path("<str:name>/", lambda request, name: HttpResponse(f"Hello {name}!")),
 ]


### PR DESCRIPTION
Unless there was a specific reason for using `re_path`, this should work equally well and is easier to read.